### PR TITLE
Specify dart 2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,14 +25,14 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'ly.eval.flutteramplitude'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.1.51'
+    ext.kotlin_version = '1.3.20'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
-    implementation 'com.amplitude:android-sdk:2.16.0'
-    provided files('templibs/flutter.jar')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.amplitude:android-sdk:2.19.0'
+    compileOnly files('templibs/flutter.jar')
 }

--- a/android/src/main/kotlin/ly/eval/flutteramplitude/FlutterAmplitudePlugin.kt
+++ b/android/src/main/kotlin/ly/eval/flutteramplitude/FlutterAmplitudePlugin.kt
@@ -28,10 +28,10 @@ class FlutterAmplitudePlugin() : MethodCallHandler {
     override fun onMethodCall(call: MethodCall, result: Result): Unit {
         when {
             call.method == "initAmplitudeSDK" -> {
-                val apiKey = call.argument<String>("apiKey")
-                val enableLogging = call.argument<Boolean>("enableLogging")
-                val enableForegroundTracking = call.argument<Boolean>("enableForegroundTracking")
-                val enableLocationListening = call.argument<Boolean>("enableLocationListening")
+                val apiKey = call.argument<String>("apiKey")!!
+                val enableLogging = call.argument<Boolean>("enableLogging")!!
+                val enableForegroundTracking = call.argument<Boolean>("enableForegroundTracking")!!
+                val enableLocationListening = call.argument<Boolean>("enableLocationListening")!!
                 initSDK(apiKey, enableLogging, enableForegroundTracking, enableLocationListening)
             }
             call.method == "logEvent" -> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,3 +12,7 @@ flutter:
   plugin:
     androidPackage: ly.eval.flutteramplitude
     pluginClass: FlutterAmplitudePlugin
+
+environment:
+  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  flutter: ">=0.1.4 <2.0.0"


### PR DESCRIPTION
Without this I get `Because x depends on flutter_amplitude >=0.0.2 which requires SDK version <2.0.0, version solving failed.` whenever I try to do `flutter upgrade`. I think that if not specified, dart below 2.0 is assumed by default.

The code is actually the same as most of the official flutter plugins.